### PR TITLE
Add support for #*DZ as thousands of dollars

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Compared to the standard number handling:
   - `12*/34` produces "12.34"
 - `*S` will add a comma after
   - `12*S/340*/50` produces "12,340.50"
+- `*DZ` will convert a number to thousands of dollars, and works with multiple strokes
+  - `3*DZ` or `3/#*DZ` produces "$3,000"
+  - `256/0*DZ` produces "$2,560,000"
 - `*Z` will add the suffix ',000'
   - `12*Z` or `12/*Z` produces "12,000"
   - `12*Z/*Z` produces "12,000,000"

--- a/jeff-numbers.py
+++ b/jeff-numbers.py
@@ -63,7 +63,10 @@ def lookup(key):
             needs_space = True
             next_error = True
         elif 'DZ' in control:
-            result = result + r'00 {*($c)}'
+            if '*' in control:
+                result = result + r'000 {*($c)}'
+            else:
+                result = result + r'00 {*($c)}'
             needs_space = True
             next_error = True
             use_glue = False


### PR DESCRIPTION
With current functionality, `Z` turns a number into hundreds, `DZ` turns a number into hundreds of dollars, and `*Z` turns a number into thousands. Intuition suggests that `*DZ` would turn a number into thousands of dollars, but the dictionary does not currently support this.

To an extent this can be worked around with `0DZ` as a suffix, but this proves limited when steno order, even with inversion, doesn't allow 0 to be the last digit (e.g. $208,000 cannot be written as a single stroke).

This PR makes this suffix work and edits the existing documentation to reflect this, positioned relative to the existing *Z entry similarly to the DZ/Z entries.. All existing examples in the README still work correctly, and other scattered testing indicates that it functions as expected with outlines like `2*EU8DZ` and various combinations using it as a suffix stroke.